### PR TITLE
Downgrade @eslint/js to v9.34.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
 		"@angular/language-service": "22.0.7",
 		"@angular/platform-browser-dynamic": "22.0.7",
 		"@eslint/eslintrc": "^3.3.1",
-		"@eslint/js": "^10.0.1",
+		"@eslint/js": "^9.34.0",
 		"@graphql-codegen/cli": "^7.2.0",
 		"@graphql-codegen/client-preset": "^6.1.0",
 		"@graphql-typed-document-node/core": "^3.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -136,8 +136,8 @@ importers:
         specifier: ^3.3.1
         version: 3.3.1
       '@eslint/js':
-        specifier: ^10.0.1
-        version: 10.0.1(eslint@9.34.0(jiti@2.7.0)(supports-color@8.1.1))
+        specifier: ^9.34.0
+        version: 9.34.0
       '@graphql-codegen/cli':
         specifier: ^7.2.0
         version: 7.2.0(@parcel/watcher@2.5.0)(@types/node@22.20.1)(graphql@16.11.0)(typescript@6.0.3)
@@ -1904,15 +1904,6 @@ packages:
   '@eslint/eslintrc@3.3.1':
     resolution: {integrity: sha512-gtF186CXhIl1p4pJNGZw8Yc6RlshoePRvE0X91oPGb3vZ8pM3qOS9W9NGPat9LziaBV7XrJWGylNQXkGcnM3IQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@eslint/js@10.0.1':
-    resolution: {integrity: sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==}
-    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
-    peerDependencies:
-      eslint: ^10.0.0
-    peerDependenciesMeta:
-      eslint:
-        optional: true
 
   '@eslint/js@9.34.0':
     resolution: {integrity: sha512-EoyvqQnBNsV1CWaEJ559rxXL4c8V92gxirbawSmVUOWXlsRxxQXl6LmCpdUblgxgSkDIqKnhzba2SjRTI/A5Rw==}
@@ -6783,6 +6774,7 @@ packages:
   eslint@9.34.0:
     resolution: {integrity: sha512-RNCHRX5EwdrESy3Jc9o8ie8Bog+PeYvvSR8sDGoZxNFTvZ4dlxUB3WzQ3bQMztFrSRODGrLLj8g6OFuGY/aiQg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
     peerDependencies:
       jiti: '*'
@@ -13448,10 +13440,6 @@ snapshots:
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
       - supports-color
-
-  '@eslint/js@10.0.1(eslint@9.34.0(jiti@2.7.0)(supports-color@8.1.1))':
-    optionalDependencies:
-      eslint: 9.34.0(jiti@2.7.0)(supports-color@8.1.1)
 
   '@eslint/js@9.34.0': {}
 


### PR DESCRIPTION
## Summary
Downgrade the `@eslint/js` dependency from version 10.0.1 to 9.34.0.

## Changes
- Updated `@eslint/js` version constraint in package.json from `^10.0.1` to `^9.34.0`

## Details
This downgrade may be necessary to resolve compatibility issues with the current project setup or to maintain consistency with other ESLint-related dependencies in the development environment.

https://claude.ai/code/session_01UigDuocQuEmjqEvfeheF8M